### PR TITLE
Added line to increase allowable number of open files.

### DIFF
--- a/install4ubuntu.sh
+++ b/install4ubuntu.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+sudo sh -c "ulimit -n 65535 && exec su $LOGNAME"
 sudo apt-get upgrade
 sudo apt-get update
 apt-get -y --force-yes install \


### PR DESCRIPTION
Issue when trying to run `install4ubuntu.sh`. Installation failed because allowable number of open files was reached. New line added to increase how many files can be open so that the installation doesn't fail.